### PR TITLE
feat: add `entrypoint` property to worker script models

### DIFF
--- a/internal/services/workers_script/model.go
+++ b/internal/services/workers_script/model.go
@@ -126,6 +126,7 @@ type WorkersScriptMetadataBindingsModel struct {
 	QueueName     types.String                                `tfsdk:"queue_name" json:"queue_name,optional"`
 	BucketName    types.String                                `tfsdk:"bucket_name" json:"bucket_name,optional"`
 	Service       types.String                                `tfsdk:"service" json:"service,optional"`
+	Entrypoint    types.String                                `tfsdk:"entrypoint" json:"entrypoint,optional"`
 	IndexName     types.String                                `tfsdk:"index_name" json:"index_name,optional"`
 	SecretName    types.String                                `tfsdk:"secret_name" json:"secret_name,optional"`
 	StoreID       types.String                                `tfsdk:"store_id" json:"store_id,optional"`

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -113,7 +113,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Required:    true,
 						},
 						"type": schema.StringAttribute{
-							Description: "The kind of resource that the binding provides.\nAvailable values: \"ai\", \"analytics_engine\", \"assets\", \"browser\", \"d1\", \"dispatch_namespace\", \"durable_object_namespace\", \"hyperdrive\", \"json\", \"kv_namespace\", \"mtls_certificate\", \"plain_text\", \"pipelines\", \"queue\", \"r2_bucket\", \"secret_text\", \"service\", \"entrypoint\", \"tail_consumer\", \"vectorize\", \"version_metadata\", \"secrets_store_secret\", \"secret_key\".",
+							Description: "The kind of resource that the binding provides.\nAvailable values: \"ai\", \"analytics_engine\", \"assets\", \"browser\", \"d1\", \"dispatch_namespace\", \"durable_object_namespace\", \"hyperdrive\", \"json\", \"kv_namespace\", \"mtls_certificate\", \"plain_text\", \"pipelines\", \"queue\", \"r2_bucket\", \"secret_text\", \"service\", \"tail_consumer\", \"vectorize\", \"version_metadata\", \"secrets_store_secret\", \"secret_key\".",
 							Required:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOfCaseInsensitive(
@@ -134,7 +134,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"r2_bucket",
 									"secret_text",
 									"service",
-									"entrypoint",
 									"tail_consumer",
 									"vectorize",
 									"version_metadata",

--- a/internal/services/workers_script/schema.go
+++ b/internal/services/workers_script/schema.go
@@ -113,7 +113,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Required:    true,
 						},
 						"type": schema.StringAttribute{
-							Description: "The kind of resource that the binding provides.\nAvailable values: \"ai\", \"analytics_engine\", \"assets\", \"browser\", \"d1\", \"dispatch_namespace\", \"durable_object_namespace\", \"hyperdrive\", \"json\", \"kv_namespace\", \"mtls_certificate\", \"plain_text\", \"pipelines\", \"queue\", \"r2_bucket\", \"secret_text\", \"service\", \"tail_consumer\", \"vectorize\", \"version_metadata\", \"secrets_store_secret\", \"secret_key\".",
+							Description: "The kind of resource that the binding provides.\nAvailable values: \"ai\", \"analytics_engine\", \"assets\", \"browser\", \"d1\", \"dispatch_namespace\", \"durable_object_namespace\", \"hyperdrive\", \"json\", \"kv_namespace\", \"mtls_certificate\", \"plain_text\", \"pipelines\", \"queue\", \"r2_bucket\", \"secret_text\", \"service\", \"entrypoint\", \"tail_consumer\", \"vectorize\", \"version_metadata\", \"secrets_store_secret\", \"secret_key\".",
 							Required:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOfCaseInsensitive(
@@ -134,6 +134,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									"r2_bucket",
 									"secret_text",
 									"service",
+									"entrypoint",
 									"tail_consumer",
 									"vectorize",
 									"version_metadata",
@@ -224,6 +225,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"service": schema.StringAttribute{
 							Description: "Name of Worker to bind to.",
+							Optional:    true,
+						},
+						"entrypoint": schema.StringAttribute{
+							Description: "Name of the Worker entrypoint to bind to.",
 							Optional:    true,
 						},
 						"index_name": schema.StringAttribute{


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Ensures the `entrypoint` binding property (used for service bindings that specify an explicit entrypoint) gets propagated to the CF API.

## Additional context & links

https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/rpc/#named-entrypoints